### PR TITLE
Random distributions now use `np.random.default_rng()`

### DIFF
--- a/ANNarchy/core/Global.py
+++ b/ANNarchy/core/Global.py
@@ -304,15 +304,21 @@ def dt() -> float:
 ################################
 def set_seed(seed:int, use_seed_seq:bool=True, net_id:int=0):
     """
-    Sets the seed of the random number generators, both in numpy.random and in the C++ library when it is created.
+    Sets the seed of the random number generators, both in ANNarchy.RandomDistributions and in the C++ library when it is created.
+
+    Numpy still has to be seeded explicitly when using the default RNG, for example:
+
+    ```python
+    ann.set_seed(seed=42)
+    rng = np.random.default_rng(seed=42)
+    A = rng.uniform(0.0, 1.0, (10, 10))
+    ```
     
     :param seed: integer value used to seed the C++ and Numpy RNG
     :param use_seed_seq: for openMP and parallel RNGs, we use either the STL SeedSequence (True, default) or a specialized implementation proposed by Melissa O'Neil (False, see _optimization_flags for more details).
     """
     _update_global_config('seed', seed)
     _update_global_config('use_seed_seq', use_seed_seq)
-    if seed > -1:
-        np.random.seed(seed)
     
     try:
         if get_global_config('disable_parallel_rng'):

--- a/ANNarchy/core/Network.py
+++ b/ANNarchy/core/Network.py
@@ -723,10 +723,10 @@ def _parallel_multi(method, number, max_processes, measure_time, sequential, sam
             raise NotImplementedError
 
     # Seed
-    if same_seed and get_global_config('seed') > -1: # use the global seed
+    if same_seed and get_global_config('seed') is not None: # use the global seed
         seed = get_global_config('seed')
     else: # draw it everytime with time(0)
-        seed = np.random.get_state()[1][0]
+        seed = np.random.get_state()[1][0] # old api < 1.17
 
     # Build arguments list for each instance with the following structure:
     # [ net_id, arguments for method, seed ]

--- a/ANNarchy/core/Random.py
+++ b/ANNarchy/core/Random.py
@@ -6,6 +6,7 @@
 import numpy as np
 
 from ANNarchy.intern import Messages
+from ANNarchy.intern.ConfigManagement import get_global_config
 
 distributions_arguments = {
     'Uniform' : 2,
@@ -71,8 +72,11 @@ class Uniform(RandomDistribution):
 
     :param min: minimum value.
     :param max: maximum value.
+    :param seed: (optional) seed for the random generator. If left None, the value set in `ann.setup()` is used.
     """
-    def __init__(self, min: float, max:float):
+    def __init__(self, min: float, max:float, seed:int=None):
+
+        self.rng = np.random.default_rng(seed=seed if seed is not None else get_global_config('seed'))
 
         self.min = min
         self.max = max
@@ -84,7 +88,7 @@ class Uniform(RandomDistribution):
         :param shape: Shape of the array.
         :returns: Array.
         """
-        return np.random.uniform(self.min, self.max, shape)
+        return self.rng.uniform(self.min, self.max, shape)
 
     def latex(self):
         return "$\\mathcal{U}$(" + str(self.min) + ', ' + str(self.max) + ')'
@@ -100,8 +104,10 @@ class DiscreteUniform(RandomDistribution):
 
     :param min: minimum value.
     :param max: maximum value.
+    :param seed: (optional) seed for the random generator. If left None, the value set in `ann.setup()` is used.
     """
-    def __init__(self, min: int, max:int):
+    def __init__(self, min: int, max:int, seed:int=None):
+        self.rng = np.random.default_rng(seed=seed if seed is not None else get_global_config('seed'))
 
         self.min = min
         self.max = max
@@ -114,7 +120,7 @@ class DiscreteUniform(RandomDistribution):
         :returns: Array.
         """
         # randint draws from half-open interval [min, max)
-        return np.random.randint(self.min, self.max+1, shape)
+        return self.rng.integers(self.min, self.max+1, shape)
 
     def latex(self):
         return "$\\mathcal{U}$(" + str(self.min) + ', ' + str(self.max) + ')'
@@ -128,12 +134,16 @@ class Normal(RandomDistribution):
     :param sigma: Standard deviation of the distribution.
     :param min: Minimum value (default: unlimited).
     :param max: Maximum value (default: unlimited).
+    :param seed: (optional) seed for the random generator. If left None, the value set in `ann.setup()` is used.
     """
-    def __init__(self, mu:float, sigma:float, min:float=None, max:float=None) -> None:
+    def __init__(self, mu:float, sigma:float, min:float=None, max:float=None, seed:int=None) -> None:
 
         if sigma < 0.0:
             Messages._error("Normal: the standard deviation sigma should be positive.")
         
+         
+        self.rng = np.random.default_rng(seed=seed if seed is not None else get_global_config('seed'))
+
         self.mu = mu
         self.sigma = sigma
         self.min = min
@@ -146,7 +156,8 @@ class Normal(RandomDistribution):
         :param shape: Shape of the array.
         :returns: Array.
         """
-        data = np.random.normal(self.mu, self.sigma, shape)
+        data = self.rng.normal(self.mu, self.sigma, shape)
+
         if self.min != None:
             data[data<self.min] = self.min
         if self.max != None:
@@ -167,11 +178,15 @@ class LogNormal(RandomDistribution):
     :param sigma: Standard deviation of the distribution.
     :param min: Minimum value (default: unlimited).
     :param max: Maximum value (default: unlimited).
+    :param seed: (optional) seed for the random generator. If left None, the value set in `ann.setup()` is used.
     """
-    def __init__(self, mu:float, sigma:float, min:float=None, max:float=None):
+    def __init__(self, mu:float, sigma:float, min:float=None, max:float=None, seed:int=None):
 
         if sigma < 0.0:
             Messages._error("LogNormal: the standard deviation sigma should be positive.")
+
+        self.rng = np.random.default_rng(seed=seed if seed is not None else get_global_config('seed'))
+
         self.mu = mu
         self.sigma = sigma
         self.min = min
@@ -184,7 +199,8 @@ class LogNormal(RandomDistribution):
         :param shape: Shape of the array.
         :returns: Array.
         """
-        data = np.random.lognormal(self.mu, self.sigma, shape)
+        data = self.rng.lognormal(self.mu, self.sigma, shape)
+
         if self.min != None:
             data[data<self.min] = self.min
         if self.max != None:
@@ -208,11 +224,14 @@ class Exponential(RandomDistribution):
     :param Lambda: rate parameter.
     :param min: minimum value (default: unlimited).
     :param max: maximum value (default: unlimited).
+    :param seed: (optional) seed for the random generator. If left None, the value set in `ann.setup()` is used.
     """
-    def __init__(self, Lambda:float, min:float=None, max:float=None):
+    def __init__(self, Lambda:float, min:float=None, max:float=None, seed:int=None):
 
         if Lambda < 0.0:
             Messages._error("Exponential: the rate parameter Lambda should be positive.")
+
+        self.rng = np.random.default_rng(seed=seed if seed is not None else get_global_config('seed'))
         
         self.Lambda = Lambda
         self.min = min
@@ -225,7 +244,8 @@ class Exponential(RandomDistribution):
         :param shape: Shape of the array.
         :returns: Array.
         """
-        data = np.random.exponential(self.Lambda, shape)
+        data = self.rng.exponential(self.Lambda, shape)
+
         if self.min != None:
             data[data<self.min] = self.min
         if self.max != None:
@@ -243,8 +263,11 @@ class Gamma(RandomDistribution):
     :param beta: Scale of the gamma distribution.
     :param min: Minimum value returned (default: unlimited).
     :param max: Maximum value returned (default: unlimited).
+    :param seed: (optional) seed for the random generator. If left None, the value set in `ann.setup()` is used.
     """
-    def __init__(self, alpha:float, beta:float=1.0, seed:int=-1, min:float=None, max:float=None):
+    def __init__(self, alpha:float, beta:float=1.0, min:float=None, max:float=None, seed:int=None):
+
+        self.rng = np.random.default_rng(seed=seed if seed is not None else get_global_config('seed'))
 
         self.alpha = alpha
         self.beta = beta
@@ -258,7 +281,8 @@ class Gamma(RandomDistribution):
         :param shape: Shape of the array.
         :returns: Array.
         """
-        data = np.random.gamma(self.alpha, self.beta, shape)
+        data = self.rng.gamma(self.alpha, self.beta, shape)
+
         if self.min != None:
             data[data<self.min] = self.min
         if self.max != None:
@@ -278,9 +302,13 @@ class Binomial(RandomDistribution):
 
     :param n: Number of trials.
     :param p: Probability of success.
+    :param seed: (optional) seed for the random generator. If left None, the value set in `ann.setup()` is used.
     """
 
-    def __init__(self, n:int, p:float):
+    def __init__(self, n:int, p:float, seed:int=None):
+
+        self.rng = np.random.default_rng(seed=seed if seed is not None else get_global_config('seed'))
+
         self.n = n
         self.p = p
 
@@ -291,7 +319,7 @@ class Binomial(RandomDistribution):
         :param shape: Shape of the array.
         :returns: Array.
         """
-        return np.random.binomial(self.n, self.p, size=shape)
+        return self.rng.binomial(self.n, self.p, size=shape)
 
     def latex(self):
         return "$\\mathcal{B}$(" + str(self.n) + ", " + str(self.p) + ")"

--- a/ANNarchy/generator/Compiler.py
+++ b/ANNarchy/generator/Compiler.py
@@ -784,9 +784,9 @@ def _instantiate(net_id, import_id=-1, cuda_config=None, user_config=None, core_
     # Instantiate CPP objects
     cython_module.pyx_create()
 
-    # Configure seeds for random number generators
+    # Configure seeds for C++ random number generators
     # Required for state updates and also (in future) construction of connectivity
-    if get_global_config('seed') == -1:
+    if get_global_config('seed') is None:
         seed = time.time()
     else:
         seed = get_global_config('seed')


### PR DESCRIPTION
…instead of the global RNG, as needed since numpy 1.17. The default seed is now None instead of -1.