### PR TITLE
Use strict=False for CodePrinter

### DIFF
--- a/ANNarchy/parser/Equation.py
+++ b/ANNarchy/parser/Equation.py
@@ -151,11 +151,21 @@ class Equation(object):
         Changes to this method should be applied also
         on ANNarchy.parser.CoupledEquations.c_code() too.
         """
-        c_code = sp.ccode(
-            equation,
-            precision=8,
-            user_functions=self.user_functions
-        )
+        # The `strict` parameter has been introduced in sympy >= 1.13.
+        # It defaults to `True`.
+        try:
+            c_code = sp.ccode(
+                equation,
+                precision=8,
+                strict=False,
+                user_functions=self.user_functions
+            )
+        except TypeError:
+            c_code = sp.ccode(
+                equation,
+                precision=8,
+                user_functions=self.user_functions
+            )
 
         if get_global_config('precision')=="float":
             #
@@ -731,5 +741,3 @@ class Equation(object):
             if self.local_dict[att] in self.analysed.atoms():
                 deps.append(att)
         return deps
-
-

--- a/ANNarchy/parser/Function.py
+++ b/ANNarchy/parser/Function.py
@@ -93,8 +93,22 @@ class FunctionParser(object):
             Messages._print(expression)
             Messages._error('The function depends on unknown variables.')
 
-        return sp.ccode(eq, precision=8,
-            user_functions=self.user_functions)
+        # The `strict` parameter has been introduced in sympy >= 1.13.
+        # It defaults to `True`.
+        try:
+            c_code = sp.ccode(
+                eq,
+                precision=8,
+                strict=False,
+                user_functions=self.user_functions
+            )
+        except TypeError:
+            c_code = sp.ccode(
+                eq,
+                precision=8,
+                user_functions=self.user_functions
+            )
+        return c_code
 
     def dependencies(self):
         "For compatibility with Equation."


### PR DESCRIPTION
This is a new option introduced in 1.13.0 which defaults to `True`.
Setting it to `False` makes CodePrinter behave as before.
See: sympy/sympy/pull/25913
    
Fix #27