### PR TITLE
Implement saving of monitors as h5py files

### DIFF
--- a/ANNarchy/__init__.py
+++ b/ANNarchy/__init__.py
@@ -13,7 +13,7 @@ from .core.Projection import Projection
 from .inputs import *
 from .core.Dendrite import Dendrite
 from .core.Random import Uniform, DiscreteUniform, Normal, LogNormal, Gamma, Exponential, Binomial
-from .core.IO import save, load, load_parameter, load_parameters, save_parameters
+from .core.IO import save, load, load_parameter, load_parameters, save_parameters, MonitorList
 from .core.Utils import sparse_random_matrix, sparse_delays_from_weights
 from .core.Monitor import *
 from .core.Network import Network, parallel_run

--- a/ANNarchy/core/IO.py
+++ b/ANNarchy/core/IO.py
@@ -584,7 +584,8 @@ def _net_description(populations, projections, net_id=0):
 
 class MonitorList(list):
     """
-    A helper list of monitors for easy saving as a h5py.File
+    A helper object to gather monitors for easy saving as a h5py file.
+
     Example:
 
     ```python
@@ -593,7 +594,7 @@ class MonitorList(list):
         Monitor(pop2, 'r')
     ])
 
-    monitors.save_all("montitors.hdf5")
+    monitors.save_all("monitors.hdf5")
     ```
     """
     def save_all(self, filename: str, keep: bool = False, reshape: bool = False, flat_keys: bool = False) -> None:

--- a/ANNarchy/core/Monitor.py
+++ b/ANNarchy/core/Monitor.py
@@ -18,9 +18,10 @@ import re
 import sys
 from copy import copy, deepcopy
 from typing import Any
+import h5py
 
 # objects/functions that should be available by "from ANNarchy import *"
-__all__ = ["Monitor", "raster_plot", "histogram", "population_rate", "smoothed_rate", "mean_fr", "inter_spike_interval", "coefficient_of_variation"]
+__all__ = ["Monitor", "MonitorDict", "raster_plot", "histogram", "population_rate", "smoothed_rate", "mean_fr", "inter_spike_interval", "coefficient_of_variation"]
 
 class Monitor :
     """
@@ -375,6 +376,26 @@ class Monitor :
                 obj_desc = 'dendrite between '+self.object.proj.pre.name+' and '+self.object.proj.post.name
             Messages._warning('Monitor:' + obj_desc + 'cannot be stopped')
 
+    def _return_variable(self, name, keep, reshape):
+        """ Returns the value of a variable with the given name. """
+        if isinstance(self.object, (Population, PopulationView)):
+            if not reshape:
+                return self._get_population(self.object, name, keep)
+            return np.reshape(self._get_population(self.object, name, keep), (-1,) + self.object.geometry)
+        if isinstance(self.object, Projection):
+            return self._get_dendrite(self.object, name, keep)
+        if isinstance(self.object, Dendrite):
+            # Dendrites have one empty dimension
+            return self._get_dendrite(self.object, name, keep).squeeze()
+        return None
+
+    def _update_stopping_time(self, var, keep):
+        self._recorded_variables[var]['stop'][-1] = Global.get_current_step(self.net_id)
+        self._last_recorded_variables[var]['start'] = self._recorded_variables[var]['start']
+        self._last_recorded_variables[var]['stop'] = self._recorded_variables[var]['stop']
+        if not keep:
+            self._recorded_variables[var]['start'] = [Global.get_current_step(self.net_id)]
+            self._recorded_variables[var]['stop'] = [None]
 
     def get(self, variables:str | list[str]=None, 
             keep:bool=False, reshape:bool=False, force_dict:bool=False) -> dict:
@@ -391,26 +412,6 @@ class Monitor :
         :param reshape: transforms the second axis of the array to match the population's geometry (default: False).
         :return: Recorded variables
         """
-
-        def reshape_recording(self, data):
-            if not reshape:
-                return data
-            else:
-                return data.reshape((data.shape[0],) + self.object.geometry)
-
-        def return_variable(self, name, keep):
-            if isinstance(self.object, (Population, PopulationView)):
-                return reshape_recording(self, self._get_population(self.object, name, keep))
-            elif isinstance(self.object, (Dendrite, Projection)):
-                data = self._get_dendrite(self.object, name, keep)
-                # Dendrites have one empty dimension
-                if isinstance(self.object, Dendrite):
-                    data = data.squeeze()
-                return data
-            else:
-                return None
-
-
         if variables:
             if not isinstance(variables, list):
                 variables = [variables]
@@ -427,22 +428,68 @@ class Monitor :
                 name = '_sum_' + target
 
             # Retrieve the data
-            data[var] = return_variable(self, name, keep)
+            data[var] = self._return_variable(name, keep, reshape)
 
             # Update stopping time
-            self._recorded_variables[var]['stop'][-1] = Global.get_current_step(self.net_id)
-
-            self._last_recorded_variables[var]['start'] = self._recorded_variables[var]['start']
-            self._last_recorded_variables[var]['stop'] = self._recorded_variables[var]['stop']
-
-            if not keep:
-                self._recorded_variables[var]['start'] = [Global.get_current_step(self.net_id)]
-                self._recorded_variables[var]['stop'] = [None]
+            self._update_stopping_time(var, keep)
 
         if not force_dict and len(variables)==1:
             return data[variables[0]]
         else:
             return data
+
+    def save(self, filename:str, variables:str | list[str]=None,
+             keep:bool=False, reshape:bool=False, force_dict:bool=False) -> None:
+        """
+        Saves the recorded variables as a Numpy array (first dimension is time, second is neuron index).
+
+        If a single variable name is provided, the recorded values for this variable are directly saved.
+        If a list is provided or the argument left empty, a dictionary with all recorded variables is saved.
+
+        The `spike` variable of a population will be returned as a dictionary of lists, where the spike times (in steps) for each recorded neurons are saved.
+
+        :param filename: name of the save file.
+        :param variables: (list of) variables. By default, a dictionary with all variables is returned.
+        :param keep: defines if the content in memory for each variable should be kept (default: False).
+        :param reshape: transforms the second axis of the array to match the population's geometry (default: False).
+        :return: Recorded variables
+        """
+        if variables:
+            if not isinstance(variables, list):
+                variables = [variables]
+        else:
+            variables = self.variables
+            force_dict = True
+
+        ## Save as single variables as numpy array
+        if not force_dict and len(variables) == 1 and filename.endswith(".npy"):
+            name = variables[0]
+            # Sums of inputs for rate-coded populations
+            if name.startswith('sum('):
+                target = re.findall(r"\(([\w]+)\)", name)[0]
+                name = '_sum_' + target
+
+            # Retrieve the data
+            np.save(filename, self._return_variable(name, keep, reshape))
+
+            # Update stopping time
+            self._update_stopping_time(variables[0], keep)
+            return
+
+        ## Save as multiple variables as h5py File
+        with h5py.File(filename, 'w') as data:
+            for var in variables:
+                name = var
+                # Sums of inputs for rate-coded populations
+                if var.startswith('sum('):
+                    target = re.findall(r"\(([\w]+)\)", var)[0]
+                    name = '_sum_' + target
+
+                # Retrieve the data
+                data["/" + var] = self._return_variable(name, keep, reshape)
+
+                # Update stopping time
+                self._update_stopping_time(var, keep)
 
     def _get_population(self, pop, name, keep):
         try:
@@ -756,6 +803,42 @@ class Monitor :
             },
             smooth
         )
+
+
+class MonitorDict(dict):
+    """
+    A helper dictionary of monitors for easy saving as a h5py.File
+    """
+    def save_all(self, filename: str, keep: bool = False, reshape: bool = False) -> None:
+        """
+        Saves all the recorded variables as a dictionary of numpy arrays
+        (first dimension is time, second is neuron index).
+
+        The `spike` variable of a population will be returned as a dictionary of lists,
+        where the spike times (in steps) for each recorded neurons are saved.
+
+        :param filename: name of the save file.
+        :param keep: defines if the content in memory for each variable should be kept (default: False).
+        :param reshape: transforms the second axis of the array to match the population's geometry (default: False).
+        """
+        with h5py.File(filename, 'w') as data:
+            for key, mon in self.items():
+                for var in mon.variables:
+                    name = var
+                    # Sums of inputs for rate-coded populations
+                    if var.startswith('sum('):
+                        target = re.findall(r"\(([\w]+)\)", var)[0]
+                        name = '_sum_' + target
+
+                    # Retrieve the data
+                    if len(mon.variables) > 1:
+                        data[f"/{key}/{var}"] = mon._return_variable(name, keep, reshape)
+                    else:
+                        data[f"/{key}_{var}"] = mon._return_variable(name, keep, reshape)
+
+                    # Update stopping time
+                    mon._update_stopping_time(var, keep)
+
 
 def get_size(obj, seen=None):
     """

--- a/ANNarchy/core/PopulationView.py
+++ b/ANNarchy/core/PopulationView.py
@@ -130,6 +130,11 @@ class PopulationView :
     def targets(self, value):
         self.population.targets.append(value)
 
+    @property
+    def name(self) -> list[str]:
+        "Returns the name of the population."
+        return self.population.name
+
     ################################
     ## Access to attributes
     ################################

--- a/ANNarchy/core/PopulationView.py
+++ b/ANNarchy/core/PopulationView.py
@@ -131,7 +131,7 @@ class PopulationView :
         self.population.targets.append(value)
 
     @property
-    def name(self) -> list[str]:
+    def name(self) -> str:
         "Returns the name of the population."
         return self.population.name
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ scipy>1.9
 sympy>1.11
 matplotlib>=3.0
 ipykernel
+h5py
 tqdm


### PR DESCRIPTION
Saving the Monitors directly without using monitor.get might be a nice feature. The MonitorDict is an overloaded python dict that allows monitors.save_all(filename) to save the data of all monitors to a h5py file.

I am open for discussions and ideas.