### PR TITLE
fix(codegen): avoid C++ narrowing conversion in mean firing rate update

### DIFF
--- a/ANNarchy/generator/Population/CUDAGenerator.py
+++ b/ANNarchy/generator/Population/CUDAGenerator.py
@@ -939,7 +939,7 @@ class CUDAGenerator(PopulationGenerator):
                     _spike_history[i].pop(); // Suppress spikes outside the window
                     r_host_to_device = true; // the queue changed the length
                 }
-                r[i] = _mean_fr_rate * %(float_prec)s{static_cast<int>(_spike_history[i].size())};
+                r[i] = _mean_fr_rate * static_cast<%(float_prec)s>(_spike_history[i].size());
             }
 
             // transfer to device

--- a/ANNarchy/generator/Population/OpenMPGenerator.py
+++ b/ANNarchy/generator/Population/OpenMPGenerator.py
@@ -606,7 +606,7 @@ class OpenMPGenerator(PopulationGenerator):
                 while((_spike_history[i].size() != 0)&&(_spike_history[i].front() <= t - _mean_fr_window)){
                     _spike_history[i].pop(); // Suppress spikes outside the window
                 }
-                r[i] = _mean_fr_rate * %(float_prec)s{static_cast<int>(_spike_history[i].size())};
+                r[i] = _mean_fr_rate * static_cast<%(float_prec)s>(_spike_history[i].size());
             }
         } """ % {"float_prec": ConfigManager().get("precision", self._net_id)}
 

--- a/ANNarchy/generator/Population/SingleThreadGenerator.py
+++ b/ANNarchy/generator/Population/SingleThreadGenerator.py
@@ -594,7 +594,7 @@ class SingleThreadGenerator(PopulationGenerator):
                     while((_spike_history[i].size() != 0)&&(_spike_history[i].front() <= t - _mean_fr_window)){
                         _spike_history[i].pop(); // Suppress spikes outside the window
                     }
-                    r[i] = _mean_fr_rate * %(float_prec)s{static_cast<int>(_spike_history[i].size())};
+                    r[i] = _mean_fr_rate * static_cast<%(float_prec)s>(_spike_history[i].size());
                 }
             } """ % {"float_prec": ConfigManager().get("precision", self._net_id)}
 


### PR DESCRIPTION
## Summary

Spiking networks that use a mean-firing-rate window fail to compile on Clang
toolchains (e.g. macOS) because the generated C++ performs a narrowing
conversion in the firing-rate update. This PR replaces the offending
braced-initialization with an explicit `static_cast`, fixing compilation
across the single-thread, OpenMP and CUDA backends.

## Symptom

Compiling a spiking network (e.g. the `Izhikevich` documentation notebook)
aborts with:

```
pop0.hpp:304:51: error: non-constant-expression cannot be narrowed from type
'int' to 'double' in initializer list [-Wc++11-narrowing]
  304 |  r[i] = _mean_fr_rate * double{static_cast<int>(_spike_history[i].size())};
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Root cause

The generated mean firing rate code converted the spike-history size to the
float precision type using braced-initialization:

```cpp
r[i] = _mean_fr_rate * double{static_cast<int>(_spike_history[i].size())};
//                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Per the C++ standard, converting a **non-constant integer to a floating-point
type inside a braced-init-list `{}`** is a *narrowing conversion* and is
ill-formed — even though a `double` can represent every `int` value exactly,
the standard only exempts *constant* expressions. GCC merely warns about this,
but Clang treats `-Wc++11-narrowing` as a **hard error by default**, so the
build breaks on Apple/Clang toolchains.

It is not really a compiler-flag problem: silencing it with
`-Wno-c++11-narrowing` would only mask an ill-formed construct rather than fix
it.

## Fix

Replace the brace-init (and the redundant intermediate `int` cast) with a
direct `static_cast` to the precision type:

```diff
- r[i] = _mean_fr_rate * %(float_prec)s{static_cast<int>(_spike_history[i].size())};
+ r[i] = _mean_fr_rate * static_cast<%(float_prec)s>(_spike_history[i].size());
```

`static_cast` performs the conversion explicitly without triggering a narrowing
diagnostic and behaves identically on GCC, Clang and nvcc. Dropping the
intermediate `int` cast also avoids truncating very long spike histories
(`std::deque::size_type` → `int`).

## Files changed

- `source/ANNarchy/generator/Population/SingleThreadGenerator.py`
- `source/ANNarchy/generator/Population/OpenMPGenerator.py`
- `source/ANNarchy/generator/Population/CUDAGenerator.py`

## Notes

- Other `%(float_prec)s{...}` braced-inits in the generator are intentionally
  left untouched: the constant cases (`%(float_prec)s{1000}`, `%(float_prec)s{1}`)
  are exempt from the narrowing rule, and the float→float cases (`getDt`/`setDt`,
  NanoBind getters) are not the source of this failure. Only the
  integer→floating conversion was ill-formed.

## Verification

- [x] Recompile a spiking network using a `mean_fr_window` on a macOS/Clang
      toolchain (e.g. re-run the `Izhikevich` notebook) and confirm it builds.
- [ ] Confirm the OpenMP build still compiles on Linux/GCC (no regression).
- [ ] CUDA backend: confirm `nvcc` compiles the regenerated code.
